### PR TITLE
Fix isPublisher test to verify that a website string has an actual domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ const isPublisher = (publisher) => {
   if (providerRE.test(publisher)) return true
 
   // we could use an RE, but why reproduce all that effort?
-  if (!tldjs.isValid(parts[0])) return false
+  if ((!tldjs.isValid(parts[0])) && (tldjs.getPubicSuffix(parts[0]))) return true
+
   if (parts.length === 1) return true
 
   props = url.parse('https://' + publisher)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bat-publisher",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Routines to identify publishers for the BAT.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Otherwise, strings such as “no-dot-here” are allowed.