### PR TITLE
2.0.2: better favicon resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bat-publisher",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Routines to identify publishers for the BAT.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1. In some cases, the scrapped `favIcon` was lacking a protocol/host designation. In those cases, use the corresponding values from the publisher’s URL

2. If favIcon resolution fails, do not bubble-up the error — everything else is A-OK.