### PR TITLE
2.0.5: use options.windowP instead of options.rawP when scraping a page

### DIFF
--- a/getMedia.js
+++ b/getMedia.js
@@ -32,7 +32,13 @@ const mappers = {
 
     if (!mediaId) throw new Error('expecting mediaId for provider Twitch')
 
-    return ('https://www.twitch.tv/videos/' + mediaId)
+    if (mediaId.includes('_vod_')) {
+      const parts = mediaId.split('_vod_')
+      return `https://www.twitch.tv/${parts[0]}/v/${parts[1]}`
+    }
+
+    // TODO we need to define which url to use for live stream for oembed
+    return `https://www.twitch.tv/${mediaId}`
   },
 
   youtube: (mediaProps) => {

--- a/getMedia.js
+++ b/getMedia.js
@@ -143,8 +143,7 @@ const resolvers = {
       })
     }
 
-// perhaps later... `payload` above has video metadata, `result` below has author metadata
-    if ((payload._channel.optimizeP) && (payload.author_url) && (payload.author_name) && (payload.thumbnail_url)) {
+    if ((payload._channel.optimizeP) && (payload.author_url) && (payload.author_name) && (payload.author_thumbnail_url)) {
       return inner({
         publisher: payload._channel.providerName + '#channel:' + payload._channel.get(paths, parts),
         publisherType: 'provider',
@@ -153,7 +152,8 @@ const resolvers = {
         providerSuffix: 'channel',
         providerValue: paths[2],
         faviconName: payload.author_name,
-        faviconURL: payload.thumbnail_url
+        faviconURL: payload.author_thumbnail_url,
+        faviconURL2: payload.thumbnail_url
       })
     }
 
@@ -191,6 +191,7 @@ const resolvers = {
       _channel: {
         providerName: 'twitch',
         param1: 2,
+        optimizeP: true,
         validP: (paths) => { return (paths.length === 2) },
         get: (paths, parts) => {
           const cpaths = parts && parts.pathname.split('/')

--- a/getMedia.js
+++ b/getMedia.js
@@ -117,7 +117,7 @@ const resolvers = {
       server: parts.protocol + '//' + parts.host,
       path: parts.path,
       timeout: options.timeout
-    }, underscore.extend({ rawP: true }, options), (err, response, body) => {
+    }, underscore.extend({ windowP: true }, options), (err, response, body) => {
       if (err) return next(providers, mediaURL, options, firstErr || err, callback)
 
       metascraper.scrapeHtml(body).then((result) => {
@@ -325,7 +325,7 @@ const roundTrip = (params, options, callback) => {
 
   params = underscore.defaults(underscore.extend(underscore.pick(parts, 'protocol', 'hostname', 'port'), params),
                                { method: params.payload ? 'POST' : 'GET' })
-  if (options.binaryP) options.rawP = true
+  if (options.binaryP || options.windowP) options.rawP = true
   if (options.debugP) console.log('\nparams=' + JSON.stringify(params, null, 2))
 
   request = client.request(underscore.omit(params, [ 'payload', 'timeout' ]), (response) => {

--- a/getMedia.js
+++ b/getMedia.js
@@ -117,7 +117,7 @@ const resolvers = {
       server: parts.protocol + '//' + parts.host,
       path: parts.path,
       timeout: options.timeout
-    }, underscore.extend({ windowP: true }, options), (err, response, body) => {
+    }, underscore.extend({ scrapeP: true }, options), (err, response, body) => {
       if (err) return next(providers, mediaURL, options, firstErr || err, callback)
 
       metascraper.scrapeHtml(body).then((result) => {
@@ -325,7 +325,7 @@ const roundTrip = (params, options, callback) => {
 
   params = underscore.defaults(underscore.extend(underscore.pick(parts, 'protocol', 'hostname', 'port'), params),
                                { method: params.payload ? 'POST' : 'GET' })
-  if (options.binaryP || options.windowP) options.rawP = true
+  if (options.binaryP || options.scrapeP) options.rawP = true
   if (options.debugP) console.log('\nparams=' + JSON.stringify(params, null, 2))
 
   request = client.request(underscore.omit(params, [ 'payload', 'timeout' ]), (response) => {

--- a/getMedia.js
+++ b/getMedia.js
@@ -185,6 +185,7 @@ const resolvers = {
 
     const parts = url.parse(payload.author_url)
     const paths = parts && parts.pathname.split('/')
+    const provider = underscore.first(providers)
 
     const get = (paths, parts) => {
       const cpaths = parts && parts.pathname.split('/')
@@ -205,7 +206,7 @@ const resolvers = {
           publisher: 'twitch#author:' + providerValue,
           publisherType: 'provider',
           publisherURL: payload.author_url + '/videos',
-          providerName: 'twitch',
+          providerName: provider.provider_name,
           providerSuffix: 'author',
           providerValue: providerValue,
           faviconName: payload.author_name,

--- a/getMedia.js
+++ b/getMedia.js
@@ -29,16 +29,15 @@ const getPublisherFromMediaProps = (mediaProps, options, callback) => {
 const mappers = {
   twitch: (mediaProps) => {
     const mediaId = mediaProps.mediaId
+    let parts
 
     if (!mediaId) throw new Error('expecting mediaId for provider Twitch')
 
-    if (mediaId.includes('_vod_')) {
-      const parts = mediaId.split('_vod_')
-      return `https://www.twitch.tv/${parts[0]}/v/${parts[1]}`
-    }
+    if (mediaId.indexOf('_vod_') === -1) return ('https://www.twitch.tv/' + mediaId)
 
     // TODO we need to define which url to use for live stream for oembed
-    return `https://www.twitch.tv/${mediaId}`
+    parts = mediaId.split('_vod_')
+    return ('https://www.twitch.tv/' + parts[0] + '/v/' + parts[1])
   },
 
   youtube: (mediaProps) => {

--- a/getMedia.js
+++ b/getMedia.js
@@ -35,7 +35,6 @@ const mappers = {
 
     if (mediaId.indexOf('_vod_') === -1) return ('https://www.twitch.tv/' + mediaId)
 
-    // TODO we need to define which url to use for live stream for oembed
     parts = mediaId.split('_vod_')
     return ('https://www.twitch.tv/' + parts[0] + '/v/' + parts[1])
   },

--- a/getMedia.js
+++ b/getMedia.js
@@ -148,7 +148,7 @@ const resolvers = {
     cachedTrip({
       server: parts.protocol + '//' + parts.host,
       path: parts.path,
-      timeout: options.timeouut
+      timeout: options.timeout
     }, underscore.extend({ scrapeP: true }, options), (err, response, body) => {
       if (err) return next(providers, mediaURL, options, firstErr || err, callback)
 

--- a/media/providers.json
+++ b/media/providers.json
@@ -4,7 +4,7 @@
     "provider_url": "https://www.twitch.tv",
     "schemes": [],
     "domain": "api.twitch.tv",
-    "url": "https://api.twitch.tv/v4/oembed"
+    "url": "https://api.twitch.tv/v5/oembed"
   },
   {
     "provider_name": "YouTube",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bat-publisher",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Routines to identify publishers for the BAT.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
to make use of new `window.fetch` call in the browser