### PR TITLE
Switch from random-lib to brave-crypto.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ const querystring = require('querystring')
 const url = require('url')
 
 const Joi = require('joi')
+const crypto = require('brave-crypto')
 const datax = require('data-expression')
 const npminfo = require('./package.json')
-const random = require('random-lib')
 const tldjs = require('tldjs')
 const trim = require('underscore.string/trim')
 const underscore = require('underscore')
@@ -417,7 +417,7 @@ Synopsis.prototype.winners = function (n, weights) {
   // NB: if (!allP), then pinned publishers are no longer "in the running"
   if (count === 0) allP = true
   while (n > 0) {
-    const point = random.floatSync()
+    const point = crypto.random.uniform_01()
     let upper = 0
     let i
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@ambassify/backoff-strategies": "1.0.0",
     "async": "^2.5.0",
+    "brave-crypto": "^0.2.0",
     "data-expression": "1.0.0",
     "glob": "^7.1.2",
     "jimp": "0.2.28",
@@ -32,7 +33,6 @@
     "jsdom": "11.2.0",
     "node-cache": "4.1.1",
     "parse-cache-control": "1.0.1",
-    "random-lib": "^3.0.0",
     "tldjs": "2.2.0",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bat-publisher",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Routines to identify publishers for the BAT.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This mainly serves to reduce unnecessary third-party dependencies and be consistent about high-quality random samplers.

Three minor consequences on semantics for the use case here:

- Positive samples below 2^-53 are now possible.
- The value 0 had unduly large probability before, and is now effectively impossible, with probability below 2^-1074.
- The value 1 had zero probability before, and is now possible, with probability 2^-54.

I don't think any of these consequences is problematic for this use case.  (More likely to be problematic: the sum of a randomly ordered sequence of weights inside the `winners` function, against which a uniform random [0,1] sample is compared.  When signs are the same, summing smallest to largest magnitude minimizes error bound.)